### PR TITLE
[gb] Output correct val when apu dac is disabled

### DIFF
--- a/gb/gbapu.cpp
+++ b/gb/gbapu.cpp
@@ -333,10 +333,10 @@ void c_gbapu::mix()
     float right_sample = 0.0f;
 
     //output range of each channel is 0 - 15
-    float square1_out = (float)square1.get_output();
-    float square2_out = (float)square2.get_output();
-    float wave_out = (float)wave.get_output();
-    float noise_out = (float)noise.get_output();
+    float square1_out = square1.dac_power ? (float)square1.get_output() : 7.5f;
+    float square2_out = square2.dac_power ? (float)square2.get_output() : 7.5f;
+    float wave_out = wave.dac_power ? (float)wave.get_output() : 7.5f;
+    float noise_out = noise.dac_power ? (float)noise.get_output() : 7.5f;
 
     left_sample += square1_out * enable_1_l + square2_out * enable_2_l + wave_out * enable_w_l + noise_out * enable_n_l;
 
@@ -691,7 +691,7 @@ void c_gbapu::c_square::clock_sweep()
 
 int c_gbapu::c_square::get_output()
 {
-    if (enabled && dac_power && duty.get_output() /* && length.get_output()*/) {
+    if (enabled && duty.get_output() /* && length.get_output()*/) {
         return envelope.get_output();
     }
     return 0;
@@ -808,7 +808,7 @@ void c_gbapu::c_noise::clock_envelope()
 
 int c_gbapu::c_noise::get_output()
 {
-    if (enabled && dac_power) {
+    if (enabled) {
         if ((~lfsr) & 0x1) {
             return envelope.get_output();
         }
@@ -861,7 +861,7 @@ void c_gbapu::c_wave::clock()
 
 int c_gbapu::c_wave::get_output()
 {
-    if (enabled && dac_power) {
+    if (enabled) {
         return sample_buffer >> volume_shift;
     }
     return 0;

--- a/gb/gbapu.ixx
+++ b/gb/gbapu.ixx
@@ -154,6 +154,7 @@ class c_gbapu
         void power_on();
         void trigger();
         int enabled;
+        int dac_power;
 
       private:
         c_timer timer;
@@ -172,7 +173,6 @@ class c_gbapu
         int period_lo;
         int envelope_period;
         int calc_sweep();
-        int dac_power;
         int clock_divider;
     };
 
@@ -190,6 +190,7 @@ class c_gbapu
         void clock_envelope();
         void power_on();
         int enabled;
+        int dac_power;
 
       private:
         int clock_shift;
@@ -202,7 +203,6 @@ class c_gbapu
         c_timer timer;
         c_length length;
         c_envelope envelope;
-        int dac_power;
         int clock_divider;
         int next_length = 64;
     };
@@ -221,6 +221,7 @@ class c_gbapu
         void clock_length();
         void power_on();
         int enabled;
+        int dac_power;
 
       private:
         int starting_volume;
@@ -233,7 +234,6 @@ class c_gbapu
         int wave_table[32];
         int wave_pos;
         int volume_shift;
-        int dac_power;
         int period_hi;
         int period_lo;
     };


### PR DESCRIPTION
APU channels output 0 to 15 which is converted to -1.0 to 1.0. Previously, when a channel's DAC was disabled, it would output digital 0 which translates to analog -1.0.  On real hardware, when the DAC is disabled, the output should be 0.0.  This change corrects this issue and resolves noise issues that were particularly noticeable in the wave channel.